### PR TITLE
Support python 3

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7] # TODO: python3 support, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Need to migrate away from [`ipaddr`](https://pypi.org/project/ipaddr/) before moving to Python3:
> It has been superseded by `ipaddress` from the Python 3 standard library, and its Python 2 backport.