### PR TITLE
Add tests for host rename and ip address CUD

### DIFF
--- a/dns/fixtures/domains.json
+++ b/dns/fixtures/domains.json
@@ -1,0 +1,266 @@
+[
+    {
+        "pk": 2,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "hamwan.net",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 3,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "240.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 4,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "241.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 5,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "242.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 6,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "243.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 7,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "244.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 8,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "245.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 9,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "246.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 10,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "247.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 11,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "248.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 12,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "249.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 13,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "250.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 14,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "251.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 15,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "252.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 16,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "253.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 17,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "254.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 18,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "255.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 20,
+        "model": "dns.domain",
+        "fields": {
+            "account": "",
+            "name": "221.24.44.in-addr.arpa",
+            "last_check": null,
+            "master": "",
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 21,
+        "model": "dns.domain",
+        "fields": {
+            "account": "",
+            "name": "hamwan.org",
+            "last_check": null,
+            "master": "",
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 22,
+        "model": "dns.domain",
+        "fields": {
+            "account": "",
+            "name": "0.2.0.0.0.0.0.5.4.0.6.2.ip6.arpa",
+            "last_check": null,
+            "master": "",
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 24,
+        "model": "dns.domain",
+        "fields": {
+            "account": "",
+            "name": "25.44.in-addr.arpa",
+            "last_check": null,
+            "master": "",
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    },
+    {
+        "pk": 26,
+        "model": "dns.domain",
+        "fields": {
+            "account": null,
+            "name": "ip.hamwan.net",
+            "last_check": null,
+            "master": null,
+            "notified_serial": null,
+            "type": "MASTER"
+        }
+    }
+]

--- a/dns/models.py
+++ b/dns/models.py
@@ -38,11 +38,11 @@ RECORD_TYPES = [(a, a) for a in ('A', 'CNAME', 'NS', 'PTR', 'SOA', 'SRV')]
 class Domain(models.Model):
     id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255, unique=True)
-    master = models.CharField(max_length=128, blank=True)
+    master = models.CharField(max_length=128, null=True, blank=True)
     last_check = models.IntegerField(null=True, blank=True)
     type = models.CharField(max_length=6)
     notified_serial = models.IntegerField(null=True, blank=True)
-    account = models.CharField(max_length=40, blank=True)
+    account = models.CharField(max_length=40, null=True, blank=True)
 
     def __unicode__(self):
         return self.name

--- a/dns/models.py
+++ b/dns/models.py
@@ -82,6 +82,8 @@ class Record(models.Model):
         return self._generate_ampr_dns('DEL')
 
     def _save_ampr_dns_command(self, command=None):
+        if not AMPR_DNS_QUEUE:
+            return
         with open(AMPR_DNS_QUEUE, 'a') as f:
             f.write("%s\n" % self._generate_ampr_dns_add())
 

--- a/hamwanadmin/settings.py
+++ b/hamwanadmin/settings.py
@@ -182,4 +182,4 @@ LOGGING = {
 
 AMPR_DNS_FROM = "portal-dns-bot@example.com"
 AMPR_DNS_TO = "ampraddr@example.com"
-AMPR_DNS_QUEUE = '/example/path/amprdnsqueue'
+AMPR_DNS_QUEUE = False  # '/example/path/amprdnsqueue'

--- a/hamwanadmin/settings.py
+++ b/hamwanadmin/settings.py
@@ -16,7 +16,8 @@ DATABASES = {
     },
 }
 
-DATABASE_ROUTERS = ['hamwanadmin.dbrouter.DnsRouter', ]
+# Uncomment in prod where pdns is a separate database
+# DATABASE_ROUTERS = ['hamwanadmin.dbrouter.DnsRouter', ]
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts

--- a/portal/fixtures/example_host.json
+++ b/portal/fixtures/example_host.json
@@ -1,0 +1,167 @@
+[
+{
+    "pk": 1, 
+    "model": "dns.record", 
+    "fields": {
+        "ordername": "", 
+        "domain": 2, 
+        "name": "loopback.s1.seattle.hamwan.net", 
+        "prio": null, 
+        "auth": true, 
+        "content": "44.25.0.1", 
+        "ttl": null, 
+        "change_date": 2020053002, 
+        "type": "A"
+    }
+},
+{
+    "pk": 2, 
+    "model": "dns.record", 
+    "fields": {
+        "ordername": "", 
+        "domain": 24, 
+        "name": "1.0.25.44.in-addr.arpa", 
+        "prio": null, 
+        "auth": true, 
+        "content": "loopback.s1.seattle.hamwan.net", 
+        "ttl": null, 
+        "change_date": 2020053002, 
+        "type": "PTR"
+    }
+},
+{
+    "pk": 3, 
+    "model": "dns.record", 
+    "fields": {
+        "ordername": "", 
+        "domain": 2, 
+        "name": "s1.seattle.hamwan.net", 
+        "prio": null, 
+        "auth": true, 
+        "content": "loopback.s1.seattle.hamwan.net", 
+        "ttl": null, 
+        "change_date": 2020053004, 
+        "type": "CNAME"
+    }
+},
+{
+    "pk": 4, 
+    "model": "dns.record", 
+    "fields": {
+        "ordername": "", 
+        "domain": 2, 
+        "name": "ether1.s1.seattle.hamwan.net", 
+        "prio": null, 
+        "auth": true, 
+        "content": "44.25.1.1", 
+        "ttl": null, 
+        "change_date": 2020053006, 
+        "type": "A"
+    }
+},
+{
+    "pk": 5, 
+    "model": "dns.record", 
+    "fields": {
+        "ordername": "", 
+        "domain": 24, 
+        "name": "1.1.25.44.in-addr.arpa", 
+        "prio": null, 
+        "auth": true, 
+        "content": "ether1.s1.seattle.hamwan.net", 
+        "ttl": null, 
+        "change_date": 2020053004, 
+        "type": "PTR"
+    }
+},
+{
+    "pk": 6, 
+    "model": "dns.record", 
+    "fields": {
+        "ordername": "", 
+        "domain": 2, 
+        "name": "wlan1.s1.seattle.hamwan.net", 
+        "prio": null, 
+        "auth": true, 
+        "content": "44.25.2.1", 
+        "ttl": null, 
+        "change_date": 2020053008, 
+        "type": "A"
+    }
+},
+{
+    "pk": 7, 
+    "model": "dns.record", 
+    "fields": {
+        "ordername": "", 
+        "domain": 24, 
+        "name": "1.2.25.44.in-addr.arpa", 
+        "prio": null, 
+        "auth": true, 
+        "content": "wlan1.s1.seattle.hamwan.net", 
+        "ttl": null, 
+        "change_date": 2020053006, 
+        "type": "PTR"
+    }
+},
+{
+    "pk": 1, 
+    "model": "portal.site", 
+    "fields": {
+        "latitude": null, 
+        "status": "", 
+        "comment": "", 
+        "name": "seattle", 
+        "longitude": null
+    }
+},
+{
+    "pk": 1, 
+    "model": "portal.host", 
+    "fields": {
+        "name": "s1.seattle", 
+        "latitude": null, 
+        "notes": "", 
+        "site": 1, 
+        "longitude": null, 
+        "wlan_mac": "", 
+        "eth_mac": "", 
+        "owner": null, 
+        "type": "sector", 
+        "admins": []
+    }
+},
+{
+    "pk": 1, 
+    "model": "portal.ipaddress", 
+    "fields": {
+        "interface": "loopback", 
+        "ip": "44.25.0.1", 
+        "host": 1, 
+        "auto_dns": true, 
+        "primary": true
+    }
+},
+{
+    "pk": 2, 
+    "model": "portal.ipaddress", 
+    "fields": {
+        "interface": "ether1", 
+        "ip": "44.25.1.1", 
+        "host": 1, 
+        "auto_dns": true, 
+        "primary": false
+    }
+},
+{
+    "pk": 3, 
+    "model": "portal.ipaddress", 
+    "fields": {
+        "interface": "wlan1", 
+        "ip": "44.25.2.1", 
+        "host": 1, 
+        "auto_dns": true, 
+        "primary": false
+    }
+}
+]

--- a/portal/models.py
+++ b/portal/models.py
@@ -128,7 +128,7 @@ class IPAddress(models.Model):
     auto_dns = models.NullBooleanField(null=True, blank=True, default=True,
         verbose_name="Auto manage DNS", help_text="Upon saving, automatically "
         "create an A record and a PTR record for this address.")
-    primary = models.BooleanField(blank=True,
+    primary = models.BooleanField(blank=True, default=False,
         help_text="Create a CNAME from the host to this interface.")
 
     def __unicode__(self):

--- a/portal/tests.py
+++ b/portal/tests.py
@@ -1,16 +1,59 @@
-"""
-This file demonstrates writing tests using the unittest module. These will pass
-when you run "manage.py test".
-
-Replace this with more appropriate tests for your application.
-"""
+import unittest
 
 from django.test import TestCase
 
+from dns.models import Record
+from portal.models import Host, IPAddress
 
-class SimpleTest(TestCase):
-    def test_basic_addition(self):
-        """
-        Tests that 1 + 1 always equals 2.
-        """
-        self.assertEqual(1 + 1, 2)
+
+class IPAddressTest(TestCase):
+    fixtures = ['domains.json', 'example_host.json']
+
+    def _assert_address_records(self, address, want=1):
+        a_records = Record.objects.filter(type="A", content=str(address.ip))
+        self.assertEqual(want, a_records.count())
+        if want:
+            self.assertEqual(address.fqdn(), a_records[0].name)
+        ptr_record = Record.objects.filter(
+            type="PTR", content=str(address.fqdn()))
+        self.assertEqual(want, ptr_record.count())
+
+    def test_create_address(self):
+        host = Host.objects.get(name="s1.seattle")
+        ip = IPAddress(host=host, interface="wlan2", ip="44.25.2.2")
+        ip.save()
+        self._assert_address_records(ip)
+
+    @unittest.skip("update is broken")
+    def test_update_address(self):
+        old_addr = "44.25.0.1"
+        new_addr = "44.25.0.2"
+        address = IPAddress.objects.get(ip=old_addr)
+        address.ip = new_addr
+        address.save()
+        self._assert_address_records(
+            IPAddress(ip=new_addr, host=address.host, interface=address.interface), want=1)
+        self._assert_address_records(
+            IPAddress(ip=old_addr, host=address.host, interface=address.interface), want=0)
+
+    def test_delete_address(self):
+        old_addr = "44.25.0.1"
+        address = IPAddress.objects.get(ip=old_addr)
+        address.delete()
+        self._assert_address_records(address, want=0)
+
+    def test_rename_host(self):
+        host = Host.objects.get(name="s1.seattle")
+        host.name = "s2.seattle"
+        host.save()
+
+        cname_records = Record.objects.filter(type="CNAME")
+        self.assertEqual(1, cname_records.count())
+        self.assertEqual(host.fqdn(), cname_records[0].name)
+        self.assertEqual("loopback.s2.seattle.hamwan.net",
+                         cname_records[0].content)
+
+        addresses = IPAddress.objects.filter(host=host)
+        self.assertEqual(3, addresses.count())
+        for addr in addresses:
+            self._assert_address_records(addr)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ South==1.0.2
 argparse==1.2.1
 djangorestframework==3.9.1
 ipaddr==2.1.11
-psycopg2>=2.6
+psycopg2-binary>=2.6
 pyasn1==0.1.7
 wsgiref==0.1.2


### PR DESCRIPTION
```
./manage.py test portal.tests.IPAddressTest
Creating test database for alias 'default'...
FATAL ERROR - The following SQL query failed: ALTER TABLE portal_ipaddress ALTER COLUMN ip TYPE inet USING(ip::inet);
The error was: near "ALTER": syntax error
Warning: could not set TYPE inet on ip field. Only supported on postgres.
.
----------------------------------------------------------------------
Ran 1 test in 0.063s

OK
Destroying test database for alias 'default'...
```