### PR TITLE
Don't orphan DNS records

### DIFF
--- a/portal/models.py
+++ b/portal/models.py
@@ -1,6 +1,6 @@
 import subprocess
 
-from django.db import models
+from django.db import models, transaction
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.template.loader import render_to_string
@@ -222,7 +222,13 @@ class IPAddress(models.Model):
             self._remove_dns()
         super(IPAddress, self).delete()
 
+    @transaction.atomic
     def save(self, *args, **kwargs):
+        if self.pk:
+            # consider IPAddress immutable
+            self.delete()
+            self.pk = None
+
         if self.auto_dns:
             # update DNS records
             self._add_dns()

--- a/portal/tests.py
+++ b/portal/tests.py
@@ -56,3 +56,10 @@ class IPAddressTest(TestCase):
         self.assertEqual(3, addresses.count())
         for addr in addresses:
             self._assert_address_records(addr)
+
+    def test_delete_host(self):
+        host = Host.objects.get(name="s1.seattle")
+        host.delete()
+        for model in Host, IPAddress, Record:
+            self.assertFalse(model.objects.count(),
+                             msg="orphaned objects: {}".format(model.objects.all()))

--- a/portal/tests.py
+++ b/portal/tests.py
@@ -15,7 +15,7 @@ class IPAddressTest(TestCase):
         if want:
             self.assertEqual(address.fqdn(), a_records[0].name)
         ptr_record = Record.objects.filter(
-            type="PTR", content=str(address.fqdn()))
+            type="PTR", name=address._generate_ptr())
         self.assertEqual(want, ptr_record.count())
 
     def test_create_address(self):
@@ -24,7 +24,6 @@ class IPAddressTest(TestCase):
         ip.save()
         self._assert_address_records(ip)
 
-    @unittest.skip("update is broken")
     def test_update_address(self):
         old_addr = "44.25.0.1"
         new_addr = "44.25.0.2"


### PR DESCRIPTION
When IPAddress is considered immutable (support for create and delete, but not update), DNS record managemenet works correctly. This PR transparently makes IPAddresses immutable by implementing the `save()` function with an atomic `delete()` and insert.

A handler is also added to run the DNS cleanup after an IPAddress delete. The cleanup was previously not being called after batch deletions, such as cascading deletions of parent objects.