### PR TITLE
run tests in container

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -17,14 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+    - name: Build Container Image
+      run: docker build --build-arg PYTHON_VERSION=${{ matrix.python-version }} -t hamwan-portal .
     - name: Run Tests
       run: |
-        python manage.py test
+        docker run --rm hamwan-portal manage.py test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# syntax=docker/dockerfile:1.4
+ARG PYTHON_VERSION=2.7
+FROM python:$PYTHON_VERSION
+EXPOSE 8000
+WORKDIR /app 
+COPY requirements.txt /app
+RUN pip install -r requirements.txt --no-cache-dir
+COPY . /app 
+ENTRYPOINT ["python"] 
+CMD ["manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
Since Github Actions no longer support setup-python 2.7, this instead runs the tests in a python 2.7 container. This will allow us to improve test coverage before attempting to upgrade to newer versions of Python and Django.